### PR TITLE
Always wrap the middleware in an array

### DIFF
--- a/src/Http/Controllers/Api.php
+++ b/src/Http/Controllers/Api.php
@@ -13,21 +13,26 @@ class Api
      */
     public function getRoutes()
     {
-	    $routes = collect(Route::getRoutes())->map(function ($route, $index) {
-	        $routeName = $route->action['as'] ?? '';
-	        if (ends_with($routeName, '.')) {
-	            $routeName = '';
-	        }
+        $routes = collect(Route::getRoutes())->map(function ($route, $index) {
+            $routeName = $route->action['as'] ?? '';
+            if (ends_with($routeName, '.')) {
+                $routeName = '';
+            }
 
-	        return [
-	            'uri' => $route->uri,
-	            'as' => $routeName,
-	            'methods' => $route->methods,
-	            'action' => $route->action['uses'] ?? '',
-	            'middleware' => $route->action['middleware'] ?? [],
-	        ];
-	    });
+            $routeMiddleware = $route->action['middleware'] ?? [];
+            if (! is_array($routeMiddleware)) {
+                $routeMiddleware = [$routeMiddleware];
+            }
 
-	    return response()->json($routes);
+            return [
+                'uri' => $route->uri,
+                'as' => $routeName,
+                'methods' => $route->methods,
+                'action' => $route->action['uses'] ?? '',
+                'middleware' => $routeMiddleware,
+            ];
+        });
+
+        return response()->json($routes);
     }
 }


### PR DESCRIPTION
This PR makes sure the API always returns the middleware for a route in an array preventing the Vue component to split the string into characters.

![screenshot 2018-12-06 at 11 37 51](https://user-images.githubusercontent.com/1234268/49579006-6e1c1e00-f94b-11e8-8ac3-ce8086956c0b.png)
