### PR TITLE
Absence of helper functions in newest Laravel fix

### DIFF
--- a/src/Http/Controllers/Api.php
+++ b/src/Http/Controllers/Api.php
@@ -3,6 +3,7 @@
 namespace Sbine\RouteViewer\Http\Controllers;
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
 
 class Api
 {
@@ -15,7 +16,7 @@ class Api
     {
         $routes = collect(Route::getRoutes())->map(function ($route, $index) {
             $routeName = $route->action['as'] ?? '';
-            if (ends_with($routeName, '.')) {
+            if (Str::endsWith($routeName, '.')) {
                 $routeName = '';
             }
 


### PR DESCRIPTION
As explained in [this issue](https://github.com/sbine/nova-route-viewer/issues/9) by default the old Laravel helper functions are no longer available by default.

Please merge this PR to use the standard function to prevent people from forking or having to include `laravel/helpers` in their project just to resolve this issue.