### PR TITLE
Laravel helpers functions availability dropped in new Laravel

### DIFF
--- a/src/Http/Controllers/Api.php
+++ b/src/Http/Controllers/Api.php
@@ -3,6 +3,7 @@
 namespace Sbine\RouteViewer\Http\Controllers;
 
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
 
 class Api
 {
@@ -15,7 +16,7 @@ class Api
     {
         $routes = collect(Route::getRoutes())->map(function ($route, $index) {
             $routeName = $route->action['as'] ?? '';
-            if (ends_with($routeName, '.')) {
+            if (Str::endsWith($routeName, '.')) {
                 $routeName = '';
             }
 


### PR DESCRIPTION
As described in [`this issue`](https://github.com/sbine/nova-route-viewer/issues/9) new versions of Laravel no longer include the helper functions.

This PR prevents users from having to fork or include `laravel/helpers` (and therefore unneeded code) just to make this package function.