### PR TITLE
Support dynamic page titles in Nova 3.12

### DIFF
--- a/resources/js/components/Tool.vue
+++ b/resources/js/components/Tool.vue
@@ -50,6 +50,11 @@
 import RouteTable from './RouteTable';
 
 export default {
+    metaInfo() {
+      return {
+        title: 'Route Viewer'
+      }
+    },
     components: { RouteTable },
 
     data() {


### PR DESCRIPTION
Nova 3.12 introduced dynamic page titles.  The title meta tag is updated dynamically.  Route Viewer does not supply the meta title from the component.  Adding this will allow the page title to automatically update correctly in newer versions of Nova.