### PR TITLE
Display "Closure" in Action column for closure-based routes

### DIFF
--- a/src/Http/Controllers/Api.php
+++ b/src/Http/Controllers/Api.php
@@ -29,7 +29,7 @@ class Api
                 'uri' => $route->uri,
                 'as' => $routeName,
                 'methods' => $route->methods,
-                'action' => $route->action['uses'] ?? '',
+                'action' => $route->action['uses'] instanceof \Closure ? 'Closure' : ($route->action['uses'] ?? ''),
                 'middleware' => $routeMiddleware,
             ];
         });


### PR DESCRIPTION
When a route uses a closure instead of a controller (e.g. `Route::get('/foo', function () { ... })`), `$route->action['uses']` is a `Closure` instance rather than a string.

Previously, the null coalescing operator (`?? ''`) didn't catch this case because the value is not `null` — it's a `Closure` object. This resulted in the Action column being a serialised closure like:
```
O:55:"Laravel\SerializableClosure\UnsignedSerializableClosure":1:{s:12:"serializable";O:46:"Laravel\SerializableClosure\Serializers\Native":5:{s:3:"use";a:3:{s:4:"disk";s:5:"local";s:6:"config";a:5:{s:6:"driver";s:5:"local";s:4:"root";s:68:"/XXX/storage/app/private";s:5:"serve";b:1;s:5:"throw";b:1;s:6:"report";b:1;}s:12:"isProduction";b:0;}s:8:"function";s:323:"function (\Illuminate\Http\Request $request, string $path) use ($disk, $config, $isProduction) { return (new \Illuminate\Filesystem\ServeFile( $disk, $config, $isProduction ))($request, $path); }";s:5:"scope";s:47:"Illuminate\Filesystem\FilesystemServiceProvider";s:4:"this";N;s:4:"self";s:32:"0000000000001ac70000000000000000";}}
```

This fix adds an explicit `instanceof \Closure` check and displays the text `"Closure"` for such routes, matching `php artisan route:list` behavior.