### PR TITLE
fix: handle SerializableClosure in action column display

### DIFF
--- a/src/Http/Controllers/Api.php
+++ b/src/Http/Controllers/Api.php
@@ -28,11 +28,13 @@ class Api
                 $routeMiddleware = [$routeMiddleware];
             }
 
+            $action = $route->action['uses'] ?? '';
+
             return [
                 'uri' => $route->uri,
                 'as' => $routeName,
                 'methods' => $route->methods,
-                'action' => is_string($route->action['uses'] ?? '') ? ($route->action['uses'] ?? '') : 'Closure',
+                'action' => is_string($action) ? $action : 'Closure',
                 'middleware' => $routeMiddleware,
             ];
         })->values()->all();

--- a/src/Http/Controllers/Api.php
+++ b/src/Http/Controllers/Api.php
@@ -32,7 +32,7 @@ class Api
                 'uri' => $route->uri,
                 'as' => $routeName,
                 'methods' => $route->methods,
-                'action' => $route->action['uses'] instanceof \Closure ? 'Closure' : ($route->action['uses'] ?? ''),
+                'action' => is_string($route->action['uses'] ?? '') ? ($route->action['uses'] ?? '') : 'Closure',
                 'middleware' => $routeMiddleware,
             ];
         })->values()->all();


### PR DESCRIPTION
## Summary

- Fix action column displaying serialized closure objects instead of "Closure" for routes that use `SerializableClosure`

## Problem

Routes registered with `Laravel\SerializableClosure\UnsignedSerializableClosure` (e.g., the `storage/{path}` route from Laravel's `FilesystemServiceProvider`) are not instances of `\Closure`. The current `instanceof \Closure` check falls through, and the serialized closure object is cast to string, producing output like:

```
O:55:"Laravel\SerializableClosure\UnsignedSerializableClosure":1:{s:12:"serializable";...}
```

## Fix

Replace `instanceof \Closure` with `is_string()` check — any non-string action (Closure, SerializableClosure, etc.) displays as `"Closure"`. This is more robust and future-proof than adding additional `instanceof` checks.

## Backwards Compatibility

Fully backwards compatible. String controller references continue to display normally; only non-string callables are affected.