### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     "homepage": "https://github.com/sbine/nova-route-viewer",
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "laravel/nova": "^4.0 || ^5.0"
     },
     "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "homepage": "https://github.com/sbine/nova-route-viewer",
     "require": {
         "php": "^8.0",
-        "laravel/framework": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0",
+        "laravel/framework": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "laravel/nova": "^4.0 || ^5.0"
     },
     "repositories": [


### PR DESCRIPTION
## Summary

- Adds `^13.0` to the `laravel/framework` version constraint in `composer.json`

## Details

Laravel 13 was released on March 17, 2026. After reviewing the [upgrade guide](https://laravel.com/docs/13.x/upgrade), none of the breaking changes affect this package:

- No CSRF middleware references
- No queue event listeners
- No cache serialization
- No Container::call() usage with nullable defaults
- Service providers, routing, and middleware APIs remain compatible

The only change needed is the version constraint.

## Test plan

- [x] Verified no breaking API changes affect the package code
- [ ] Install in a Laravel 13 project and confirm routes load correctly