### PR TITLE
Add Laravel 11+, require PHP 8.2+, add CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,43 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+
+    name: PHP ${{ matrix.php }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Strip Nova dependency for CI
+        run: |
+          # Nova is a private package - remove it and its repo for CI
+          # Nova-dependent tests will be skipped automatically
+          php -r '
+            $json = json_decode(file_get_contents("composer.json"), true);
+            unset($json["require"]["laravel/nova"]);
+            unset($json["repositories"]);
+            file_put_contents("composer.json", json_encode($json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . "\n");
+          '
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction --no-progress
+
+      - name: Run tests
+        run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,5 +39,9 @@ jobs:
       - name: Install dependencies
         run: composer update --prefer-dist --no-interaction --no-progress
 
+      - name: Check code style
+        if: matrix.php == '8.4'
+        run: vendor/bin/pint --test
+
       - name: Run tests
         run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3', '8.4', '8.5']
+        php: ['8.2', '8.3', '8.4', '8.5']
 
     name: PHP ${{ matrix.php }}
 

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
+        "laravel/pint": "^1.29",
         "phpunit/phpunit": "^11.0 || ^12.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "homepage": "https://github.com/sbine/nova-route-viewer",
     "require": {
         "php": "^8.0",
+        "laravel/framework": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
         "laravel/nova": "^4.0 || ^5.0"
     },
     "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -30,10 +30,21 @@
     ],
     "minimum-stability": "dev",
     "prefer-stable": true,
+    "require-dev": {
+        "phpunit/phpunit": "^9.6 || ^10.5 || ^11.0 || ^12.0"
+    },
     "autoload": {
         "psr-4": {
             "Sbine\\RouteViewer\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Sbine\\RouteViewer\\Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     ],
     "homepage": "https://github.com/sbine/nova-route-viewer",
     "require": {
-        "php": "^8.0",
-        "laravel/framework": "^8.0 || ^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0",
-        "laravel/nova": "^4.0 || ^5.0"
+        "php": "^8.2",
+        "laravel/framework": "^11.0 || ^12.0 || ^13.0",
+        "laravel/nova": "^5.0"
     },
     "repositories": [
         {
@@ -31,7 +31,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "phpunit/phpunit": "^9.6 || ^10.5 || ^11.0 || ^12.0"
+        "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0"
+        "phpunit/phpunit": "^11.0 || ^12.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Tests">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Column.php
+++ b/src/Column.php
@@ -8,9 +8,13 @@ use Illuminate\Routing\Route;
 class Column
 {
     public string $label;
+
     public string $attribute;
+
     public bool $sortable = true;
+
     protected ?Closure $resolver = null;
+
     protected ?Closure $batchResolver = null;
 
     protected function __construct(string $label, string $attribute)

--- a/src/Http/Controllers/Api.php
+++ b/src/Http/Controllers/Api.php
@@ -2,6 +2,7 @@
 
 namespace Sbine\RouteViewer\Http\Controllers;
 
+use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
 use Sbine\RouteViewer\RouteViewer;
@@ -11,7 +12,7 @@ class Api
     /**
      * Return all the registered routes.
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function getRoutes()
     {

--- a/src/Http/Middleware/Authorize.php
+++ b/src/Http/Middleware/Authorize.php
@@ -2,7 +2,10 @@
 
 namespace Sbine\RouteViewer\Http\Middleware;
 
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 use Laravel\Nova\Nova;
+use Laravel\Nova\Tool;
 use Sbine\RouteViewer\RouteViewer;
 
 class Authorize
@@ -10,9 +13,9 @@ class Authorize
     /**
      * Handle the incoming request.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @param  \Closure  $next
-     * @return \Illuminate\Http\Response
+     * @return Response
      */
     public function handle($request, $next)
     {
@@ -24,7 +27,7 @@ class Authorize
     /**
      * Determine whether this tool belongs to the package.
      *
-     * @param  \Laravel\Nova\Tool  $tool
+     * @param  Tool  $tool
      * @return bool
      */
     public function matchesTool($tool)

--- a/src/RouteViewer.php
+++ b/src/RouteViewer.php
@@ -44,7 +44,6 @@ class RouteViewer extends Tool
     /**
      * Build the menu that renders the navigation links for the tool.
      *
-     * @param  \Illuminate\Http\Request $request
      * @return mixed
      */
     public function menu(Request $request)

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -44,7 +44,7 @@ class ToolServiceProvider extends ServiceProvider
 
         Route::middleware(['nova', Authorize::class])
             ->prefix('nova-vendor/route-viewer')
-            ->group(__DIR__ . '/../routes/api.php');
+            ->group(__DIR__.'/../routes/api.php');
     }
 
     /**
@@ -60,11 +60,11 @@ class ToolServiceProvider extends ServiceProvider
     protected function registerTranslations()
     {
         $currentLocale = app()->getLocale();
-        $localTranslationDir = __DIR__ . '/../resources/lang';
+        $localTranslationDir = __DIR__.'/../resources/lang';
         $novaTranslationDir = resource_path('lang/vendor/route-viewer');
 
-        Nova::translations($localTranslationDir . '/' . $currentLocale . '.json');
-        Nova::translations($novaTranslationDir . '/' . $currentLocale . '.json');
+        Nova::translations($localTranslationDir.'/'.$currentLocale.'.json');
+        Nova::translations($novaTranslationDir.'/'.$currentLocale.'.json');
 
         $this->loadTranslationsFrom($localTranslationDir, 'route-viewer');
         $this->loadJSONTranslationsFrom($localTranslationDir);

--- a/tests/ColumnTest.php
+++ b/tests/ColumnTest.php
@@ -2,6 +2,7 @@
 
 namespace Sbine\RouteViewer\Tests;
 
+use Illuminate\Routing\Route;
 use PHPUnit\Framework\TestCase;
 use Sbine\RouteViewer\Column;
 
@@ -44,7 +45,7 @@ class ColumnTest extends TestCase
         $column = Column::make('Domain', 'domain')
             ->using(fn ($route) => $route->getDomain());
 
-        $route = new \Illuminate\Routing\Route('GET', 'test', fn () => null);
+        $route = new Route('GET', 'test', fn () => null);
 
         $this->assertNull($column->resolve($route));
     }
@@ -75,7 +76,7 @@ class ColumnTest extends TestCase
     {
         $column = Column::make('Label', 'attr');
 
-        $route = new \Illuminate\Routing\Route('GET', 'test', fn () => null);
+        $route = new Route('GET', 'test', fn () => null);
 
         $this->assertNull($column->resolve($route));
     }

--- a/tests/ColumnTest.php
+++ b/tests/ColumnTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Sbine\RouteViewer\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sbine\RouteViewer\Column;
+
+class ColumnTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    public function test_it_can_be_created_with_label_and_attribute(): void
+    {
+        $column = Column::make('My Label', 'my_attribute');
+
+        $this->assertSame('My Label', $column->label);
+        $this->assertSame('my_attribute', $column->attribute);
+        $this->assertTrue($column->sortable);
+    }
+
+    public function test_it_can_be_made_non_sortable(): void
+    {
+        $column = Column::make('Label', 'attr')->sortable(false);
+
+        $this->assertFalse($column->sortable);
+    }
+
+    public function test_it_converts_to_array(): void
+    {
+        $column = Column::make('Route', 'uri')->sortable(true);
+
+        $this->assertSame([
+            'label' => 'Route',
+            'attribute' => 'uri',
+            'sortable' => true,
+        ], $column->toArray());
+    }
+
+    public function test_it_resolves_value_using_callback(): void
+    {
+        $column = Column::make('Domain', 'domain')
+            ->using(fn ($route) => $route->getDomain());
+
+        $route = new \Illuminate\Routing\Route('GET', 'test', fn () => null);
+
+        $this->assertNull($column->resolve($route));
+    }
+
+    public function test_it_has_no_batch_resolver_by_default(): void
+    {
+        $column = Column::make('Label', 'attr');
+
+        $this->assertFalse($column->hasBatchResolver());
+    }
+
+    public function test_it_resolves_batch_values(): void
+    {
+        $column = Column::make('Index', 'index')
+            ->usingBatch(fn (array $routes) => array_map(fn ($r) => $r['uri'], $routes));
+
+        $this->assertTrue($column->hasBatchResolver());
+
+        $routes = [
+            ['uri' => '/foo', 'as' => ''],
+            ['uri' => '/bar', 'as' => ''],
+        ];
+
+        $this->assertSame(['/foo', '/bar'], $column->resolveBatch($routes));
+    }
+
+    public function test_resolve_returns_null_without_resolver(): void
+    {
+        $column = Column::make('Label', 'attr');
+
+        $route = new \Illuminate\Routing\Route('GET', 'test', fn () => null);
+
+        $this->assertNull($column->resolve($route));
+    }
+
+    public function test_resolve_batch_returns_empty_array_without_resolver(): void
+    {
+        $column = Column::make('Label', 'attr');
+
+        $this->assertSame([], $column->resolveBatch([]));
+    }
+}

--- a/tests/RouteViewerTest.php
+++ b/tests/RouteViewerTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Sbine\RouteViewer\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Sbine\RouteViewer\Column;
+
+/**
+ * These tests require laravel/nova to be installed.
+ *
+ * @requires function \Laravel\Nova\Nova::registeredTools
+ */
+class RouteViewerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        \Sbine\RouteViewer\RouteViewer::flushColumns();
+        parent::tearDown();
+    }
+
+    public function test_it_starts_with_no_custom_columns(): void
+    {
+        $this->assertSame([], \Sbine\RouteViewer\RouteViewer::getColumns());
+    }
+
+    public function test_it_can_add_a_single_column(): void
+    {
+        $column = Column::make('Domain', 'domain');
+
+        \Sbine\RouteViewer\RouteViewer::addColumn($column);
+
+        $this->assertCount(1, \Sbine\RouteViewer\RouteViewer::getColumns());
+        $this->assertSame($column, \Sbine\RouteViewer\RouteViewer::getColumns()[0]);
+    }
+
+    public function test_it_can_add_multiple_columns(): void
+    {
+        $col1 = Column::make('Domain', 'domain');
+        $col2 = Column::make('Rate Limit', 'rate_limit');
+
+        \Sbine\RouteViewer\RouteViewer::addColumns($col1, $col2);
+
+        $this->assertCount(2, \Sbine\RouteViewer\RouteViewer::getColumns());
+    }
+
+    public function test_it_can_flush_columns(): void
+    {
+        \Sbine\RouteViewer\RouteViewer::addColumn(Column::make('Domain', 'domain'));
+
+        $this->assertCount(1, \Sbine\RouteViewer\RouteViewer::getColumns());
+
+        \Sbine\RouteViewer\RouteViewer::flushColumns();
+
+        $this->assertSame([], \Sbine\RouteViewer\RouteViewer::getColumns());
+    }
+}

--- a/tests/RouteViewerTest.php
+++ b/tests/RouteViewerTest.php
@@ -4,6 +4,7 @@ namespace Sbine\RouteViewer\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Sbine\RouteViewer\Column;
+use Sbine\RouteViewer\RouteViewer;
 
 /**
  * These tests require laravel/nova to be installed.
@@ -14,23 +15,23 @@ class RouteViewerTest extends TestCase
 {
     protected function tearDown(): void
     {
-        \Sbine\RouteViewer\RouteViewer::flushColumns();
+        RouteViewer::flushColumns();
         parent::tearDown();
     }
 
     public function test_it_starts_with_no_custom_columns(): void
     {
-        $this->assertSame([], \Sbine\RouteViewer\RouteViewer::getColumns());
+        $this->assertSame([], RouteViewer::getColumns());
     }
 
     public function test_it_can_add_a_single_column(): void
     {
         $column = Column::make('Domain', 'domain');
 
-        \Sbine\RouteViewer\RouteViewer::addColumn($column);
+        RouteViewer::addColumn($column);
 
-        $this->assertCount(1, \Sbine\RouteViewer\RouteViewer::getColumns());
-        $this->assertSame($column, \Sbine\RouteViewer\RouteViewer::getColumns()[0]);
+        $this->assertCount(1, RouteViewer::getColumns());
+        $this->assertSame($column, RouteViewer::getColumns()[0]);
     }
 
     public function test_it_can_add_multiple_columns(): void
@@ -38,19 +39,19 @@ class RouteViewerTest extends TestCase
         $col1 = Column::make('Domain', 'domain');
         $col2 = Column::make('Rate Limit', 'rate_limit');
 
-        \Sbine\RouteViewer\RouteViewer::addColumns($col1, $col2);
+        RouteViewer::addColumns($col1, $col2);
 
-        $this->assertCount(2, \Sbine\RouteViewer\RouteViewer::getColumns());
+        $this->assertCount(2, RouteViewer::getColumns());
     }
 
     public function test_it_can_flush_columns(): void
     {
-        \Sbine\RouteViewer\RouteViewer::addColumn(Column::make('Domain', 'domain'));
+        RouteViewer::addColumn(Column::make('Domain', 'domain'));
 
-        $this->assertCount(1, \Sbine\RouteViewer\RouteViewer::getColumns());
+        $this->assertCount(1, RouteViewer::getColumns());
 
-        \Sbine\RouteViewer\RouteViewer::flushColumns();
+        RouteViewer::flushColumns();
 
-        $this->assertSame([], \Sbine\RouteViewer\RouteViewer::getColumns());
+        $this->assertSame([], RouteViewer::getColumns());
     }
 }


### PR DESCRIPTION
## Summary

- Restore `laravel/framework` as an explicit dependency (accidentally removed in #30)
- Add Laravel 13 support (`^13.0`)
- Drop support for EOL versions: PHP 8.0–8.1, Laravel 8–10, Nova 4
- Add smoke tests for `Column` and `RouteViewer` classes
- Add GitHub Actions CI workflow (PHP 8.2, 8.3, 8.4, 8.5 matrix)

## Version requirements

| Dependency | Before | After |
|---|---|---|
| PHP | `^8.0` | `^8.2` |
| laravel/framework | _(removed in #30)_ | `^11.0 \|\| ^12.0 \|\| ^13.0` |
| laravel/nova | `^4.0 \|\| ^5.0` | `^5.0` |
| phpunit/phpunit | _(none)_ | `^11.0 \|\| ^12.0` |

## Test plan

- [x] `ColumnTest` — unit tests for Column creation, sorting, resolvers, batch resolvers
- [x] `RouteViewerTest` — tests for custom column management (skipped when Nova is not installed)
- [x] CI runs on PHP 8.2–8.5